### PR TITLE
update to Python 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,8 +139,8 @@ set(PKG_ROOT_DIR "/opt/pkg" CACHE STRING "Package root directory")
 
 # Python
 find_package(PythonInterp)
-if(PYTHON_VERSION_STRING VERSION_LESS 2.7)
-  message(FATAL_ERROR "Python version less than 2.y: \"${PYTHON_VERSION_STRING}\".")
+if(PYTHON_VERSION_STRING VERSION_LESS 3.0)
+  message(FATAL_ERROR "Python version less than 3.x: \"${PYTHON_VERSION_STRING}\".")
 endif()
 
 if(WITH_THRIFT)
@@ -308,7 +308,7 @@ install(
 install(
 	FILES 		  ${CMAKE_SOURCE_DIR}/LICENSE
 						  ${CMAKE_SOURCE_DIR}/README.md
-	DESTINATION ${CMAKE_INSTALL_PREFIX}/share 
+	DESTINATION ${CMAKE_INSTALL_PREFIX}/share
 )
 
 #===============================================================================


### PR DESCRIPTION
Some Linux distros dropped support for Python 2.x as of 2021. This PR updates `config_validator_codegen.py` to Python 3. Changes that were necessary include:

- Switch from `commands` to `subprocess`
- Use `str` instead of `unicode`
- Make `list` out of `filter` to get `len`
- Add `key` function to sort `lxml.etree.Element`
- Create `NamedTemporaryFile` with mode `w+` (default is `w+b`) so that we can write `str` to it
- Create `NamedTemporaryFile` with `delete=False` since setting it before calling `__exit__` doesn't seem to work, so we have to manually delete the temp file if we don't want to rename it